### PR TITLE
Redefine colors when running as root

### DIFF
--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -61,7 +61,7 @@ setopt PROMPT_SUBST
 
 # Override PROMPT if it does not use the gitprompt function
 [[ "$PROMPT" != *gitprompt* && "$RPROMPT" != *gitprompt* ]] \
-    && PROMPT='%B%40<..<%~ %b$(gitprompt)%(?.%F{blue}❯%f%F{cyan}❯%f%F{green}❯%f.%F{red}❯❯❯%f) '
+    && PROMPT='%B%40<..<%~ %b$(gitprompt)%(?.%F{blue}❯%F{cyan}❯%(!.%F{red}.%F{green})❯%f.%F{red}❯❯❯%f) '
 
 # Find an awk implementation
 # Prefer nawk over mawk and mawk over awk

--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -61,7 +61,7 @@ setopt PROMPT_SUBST
 
 # Override PROMPT if it does not use the gitprompt function
 [[ "$PROMPT" != *gitprompt* && "$RPROMPT" != *gitprompt* ]] \
-    && PROMPT='%B%40<..<%~ %b$(gitprompt)%(?.%F{blue}❯%F{cyan}❯%(!.%F{red}.%F{green})❯%f.%F{red}❯❯❯%f) '
+    && PROMPT='%B%40<..<%~ %b$(gitprompt)%(?.%(!.%F{white}❯%F{yellow}❯%F{red}.%F{blue}❯%F{cyan}❯%F{green})❯%f.%F{red}❯❯❯%f) '
 
 # Find an awk implementation
 # Prefer nawk over mawk and mawk over awk


### PR DESCRIPTION
Also got rid of extra `%f` sequences which reset the foreground color, but aren't needed if we're changing the color immediately after.

----

This is helpful when running with `sudo -E -s`, which uses the same environment (and therefore prompt) and is a bit hard to distinguish in which user you're running. Result:

![prompt-demo](https://user-images.githubusercontent.com/1441704/76774600-6a10ba00-67a4-11ea-90a5-b8a41e210a38.png)

