### PR TITLE
Add an ascii prompt example

### DIFF
--- a/examples/ascii.zsh
+++ b/examples/ascii.zsh
@@ -1,0 +1,22 @@
+ZSH_GIT_PROMPT_SHOW_UPSTREAM="no"
+
+ZSH_THEME_GIT_PROMPT_PREFIX=" "
+ZSH_THEME_GIT_PROMPT_SUFFIX=""
+ZSH_THEME_GIT_PROMPT_SEPARATOR=""
+ZSH_THEME_GIT_PROMPT_DETACHED="%{$fg_bold[cyan]%}:"
+ZSH_THEME_GIT_PROMPT_BRANCH="%{$fg_bold[magenta]%}"
+ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL="%{$fg_bold[yellow]%}^"
+ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX="%{$fg[red]%}(%{$fg[yellow]%}"
+ZSH_THEME_GIT_PROMPT_UPSTREAM_SUFFIX="%{$fg[red]%})"
+ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg[red]%}v"
+ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg[green]%}^"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[red]%}x"
+ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[green]%}o"
+ZSH_THEME_GIT_PROMPT_UNSTAGED="%{$fg[red]%}+"
+ZSH_THEME_GIT_PROMPT_UNTRACKED=".."
+ZSH_THEME_GIT_PROMPT_STASHED="%{$fg[blue]%}$"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}>"
+
+PROMPT='%B%40<..<%~%b$(gitprompt)'
+PROMPT+='%(?.%(!.%F{white}>%F{yellow}>%F{red}.%F{green})>%f.%F{red}>%f) '
+RPROMPT=''


### PR DESCRIPTION
I based it on the "compact" prompt. I have been using it for awhile, and
to me it feels pretty similar to the original.

I've found it useful for a multiplexer and a terminal that didn't
support unicode very well.

The basic idea behind it is this:
When the package is clean, you see ">>" which suggests "I'm done, do some other stuff". Otherwise you get only one ">". All the colours are the same as the compact one.

Colours are extra important with it, since it re-uses characters and is ambiguous on a monochrome terminal.