### PR TITLE
Add python virtual environment name as prefix to git prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,29 @@ time ZSH_GIT_PROMPT_AWK_CMD=awk zsh -f -c '
     Executing any command or simply pressing enter will fix the issue.
 * In large repositories the prompt might slow down, because Git has to find untracked files.
     See `man git-status`, Section `--untracked-files` for possible options to speed things up.
+
+### Extra
+
+Add active python virtual environment name as prefix to git prompt.
+
+
+#### Manual installation
+Clone this repo or download the [git-prompt.zsh](https://raw.githubusercontent.com/woefe/zsh-git-prompt/master/git-prompt.zsh) file.
+Then source it in your `.zshrc`. For example:
+
+```bash
+mkdir -p ~/.zsh
+git clone --depth=1 https://github.com/woefe/git-prompt.zsh ~/.zsh/git-prompt.zsh
+echo "source ~/.zsh/git-prompt.zsh/git-prompt.zsh" >> .zshrc
+echo "source ~/.zsh/git-prompt.zsh/python-virtual-environment-prompt.zsh" >> .zshrc
+
+# Install an example configuration of git prompt with active python virtual environment as prefix
+echo "source ~/.zsh/git-prompt.zsh/examples/multilinewithvenv.zsh" >> .zshrc
+```
+
+#### Preview
+If a python virtual environment named ```my_venv``` is active in a project dir named ```my_project```:
+```bash
+┏╸(my_venv) ~/workspace/my_project · ⎇ main ‹●1357›
+┗╸❯❯❯ 
+```

--- a/examples/multilinewithvenv.zsh
+++ b/examples/multilinewithvenv.zsh
@@ -1,0 +1,21 @@
+ZSH_GIT_PROMPT_FORCE_BLANK=1
+ZSH_GIT_PROMPT_SHOW_UPSTREAM="full"
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%B · %b"
+ZSH_THEME_GIT_PROMPT_SUFFIX="›"
+ZSH_THEME_GIT_PROMPT_SEPARATOR=" ‹"
+ZSH_THEME_GIT_PROMPT_BRANCH="⎇ %{$fg_bold[cyan]%}"
+ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL="%{$fg_bold[yellow]%}⟳ "
+ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX="%{$fg[yellow]%} ⤳ "
+ZSH_THEME_GIT_PROMPT_UPSTREAM_SUFFIX=""
+ZSH_THEME_GIT_PROMPT_DETACHED="%{$fg_no_bold[cyan]%}:"
+ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg_no_bold[cyan]%}↓"
+ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_no_bold[cyan]%}↑"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[red]%}✖"
+ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[green]%}●"
+ZSH_THEME_GIT_PROMPT_UNSTAGED="%{$fg[red]%}✚"
+ZSH_THEME_GIT_PROMPT_UNTRACKED="…"
+ZSH_THEME_GIT_PROMPT_STASHED="%{$fg[blue]%}⚑"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}✔"
+PROMPT=$'┏╸$(python_venv_info)%(?..%F{red}%?%f · )%B%~%b$(gitprompt)\n┗╸%F{blue}❯%f%F{cyan}❯%f%F{green}❯%f '
+RPROMPT=''

--- a/python-virtual-environment-prompt.zsh
+++ b/python-virtual-environment-prompt.zsh
@@ -1,0 +1,4 @@
+export VIRTUAL_ENV_DISABLE_PROMPT=1
+function python_venv_info() {
+  [[ -n "$VIRTUAL_ENV" ]] && echo "(`basename $VIRTUAL_ENV`) "
+}


### PR DESCRIPTION
Add active python virtual environment name as a prefix to git prompt.

Manual installation
Clone this repo or download the git-prompt.zsh file.
Then source it in your .zshrc. For example:

mkdir -p ~/.zsh
git clone --depth=1 https://github.com/woefe/git-prompt.zsh ~/.zsh/git-prompt.zsh
echo "source ~/.zsh/git-prompt.zsh/git-prompt.zsh" >> .zshrc
echo "source ~/.zsh/git-prompt.zsh/python-virtual-environment-prompt.zsh" >> .zshrc

# Install an example configuration of git prompt with active python virtual environment as a prefix
echo "source ~/.zsh/git-prompt.zsh/examples/multilinewithvenv.zsh" >> .zshrc
Preview
If a python virtual environment named my_venv is active in a project dir named my_project:

┏╸(my_venv) ~/workspace/my_project · ⎇ main ‹●1357›
┗╸❯❯❯ 


PBI: Currently, only one prompt style is created in the example dir named multilinewithvenv.zsh.