### PR TITLE
A few new features

### DIFF
--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -37,6 +37,7 @@ autoload -U colors && colors
 : "${ZSH_THEME_GIT_PROMPT_BRANCH="%{$fg_bold[magenta]%}"}"
 : "${ZSH_THEME_GIT_PROMPT_BRANCH_PREFIX="${ZSH_THEME_GIT_PROMPT_BRANCH}"}"
 : "${ZSH_THEME_GIT_PROMPT_BRANCH_SUFFIX=""}"
+: "${ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_PREFIX=""}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL="%{$fg_bold[yellow]%}⟳ "}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX="%{$fg[red]%}(%{$fg[yellow]%}"}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_SUFFIX="%{$fg[red]%})"}"
@@ -88,6 +89,7 @@ function _zsh_git_prompt_git_status() {
         -v DETACHED="$ZSH_THEME_GIT_PROMPT_DETACHED" \
         -v BRANCH_PREFIX="$ZSH_THEME_GIT_PROMPT_BRANCH_PREFIX" \
         -v BRANCH_SUFFIX="$ZSH_THEME_GIT_PROMPT_BRANCH_SUFFIX" \
+        -v BEHIND_AHEAD_PREFIX="$ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_PREFIX" \
         -v UPSTREAM_TYPE="$ZSH_GIT_PROMPT_SHOW_UPSTREAM" \
         -v UPSTREAM_SYMBOL="$ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL" \
         -v UPSTREAM_PREFIX="$ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX" \
@@ -198,12 +200,16 @@ function _zsh_git_prompt_git_status() {
                 print RC;
 
                 if (behind < 0) {
+                    print BEHIND_AHEAD_PREFIX;
                     print BEHIND;
                     printf "%d", behind * -1;
                     print RC;
                 }
 
                 if (ahead > 0) {
+                    if (behind == 0) {
+                        print BEHIND_AHEAD_PREFIX;
+                    }
                     print AHEAD;
                     printf "%d", ahead;
                     print RC;

--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -35,6 +35,8 @@ autoload -U colors && colors
 : "${ZSH_THEME_GIT_PROMPT_SEPARATOR="|"}"
 : "${ZSH_THEME_GIT_PROMPT_DETACHED="%{$fg_bold[cyan]%}:"}"
 : "${ZSH_THEME_GIT_PROMPT_BRANCH="%{$fg_bold[magenta]%}"}"
+: "${ZSH_THEME_GIT_PROMPT_BRANCH_PREFIX="${ZSH_THEME_GIT_PROMPT_BRANCH}"}"
+: "${ZSH_THEME_GIT_PROMPT_BRANCH_SUFFIX=""}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL="%{$fg_bold[yellow]%}⟳ "}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX="%{$fg[red]%}(%{$fg[yellow]%}"}"
 : "${ZSH_THEME_GIT_PROMPT_UPSTREAM_SUFFIX="%{$fg[red]%})"}"
@@ -84,7 +86,8 @@ function _zsh_git_prompt_git_status() {
         -v SUFFIX="$ZSH_THEME_GIT_PROMPT_SUFFIX" \
         -v SEPARATOR="$ZSH_THEME_GIT_PROMPT_SEPARATOR" \
         -v DETACHED="$ZSH_THEME_GIT_PROMPT_DETACHED" \
-        -v BRANCH="$ZSH_THEME_GIT_PROMPT_BRANCH" \
+        -v BRANCH_PREFIX="$ZSH_THEME_GIT_PROMPT_BRANCH_PREFIX" \
+        -v BRANCH_SUFFIX="$ZSH_THEME_GIT_PROMPT_BRANCH_SUFFIX" \
         -v UPSTREAM_TYPE="$ZSH_GIT_PROMPT_SHOW_UPSTREAM" \
         -v UPSTREAM_SYMBOL="$ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL" \
         -v UPSTREAM_PREFIX="$ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX" \
@@ -170,9 +173,10 @@ function _zsh_git_prompt_git_status() {
                     print DETACHED;
                     print substr(oid, 0, 7);
                 } else {
-                    print BRANCH;
+                    print BRANCH_PREFIX;
                     gsub("%", "%%", head);
                     print head;
+                    print BRANCH_SUFFIX;
                 }
                 print RC;
 

--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -186,6 +186,11 @@ function _zsh_git_prompt_git_status() {
                         print UPSTREAM_SUFFIX;
                     }
                 }
+                else {
+                    if (UPSTREAM_TYPE == "localsymbol") {
+                        print UPSTREAM_SYMBOL;
+                    }
+                }
                 print RC;
 
                 if (behind < 0) {


### PR DESCRIPTION
If you specify `localsymbol` as the `ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL`, then the symbol will be printed if the current branch has no remote (effectively the opposite of `symbol`).  This way, you can see a warning for branches that haven't been pushed, as opposed to a confirmation for ones that have.

Added `ZSH_THEME_GIT_PROMPT_BRANCH_PREFIX` and `ZSH_THEME_GIT_PROMPT_BRANCH_SUFFIX`.  Allows you to do things like adding a space after the branch name, so the ahead and behind indicators aren't bunched up against it.  For compatibility, `ZSH_THEM_GIT_PROMPT_BRANCH_PREFIX` defaults to `$ZSH_THEM_GIT_PROMPT_BRANCH`.

Added `ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_PREFIX` which appears before the behind/ahead indicators, but only if one or both of them are to be printed.