### PR TITLE
Add options to disable tracking and local counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,21 @@ The `symbol` option prints only `ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL`.
 Furthermore, a warning symbol can be configured through `ZSH_THEME_GIT_PROMPT_UPSTREAM_NO_TRACKING` for the case where no remote is available.
 `ZSH_THEME_GIT_PROMPT_UPSTREAM_NO_TRACKING` can be set independently of `ZSH_GIT_PROMPT_SHOW_UPSTREAM`.
 
-### Show number of stash entries
-The number of stash entries will be shown if `ZSH_GIT_PROMPT_SHOW_STASH` is set.
+### Show whether there are stash entries
+If `ZSH_GIT_PROMPT_SHOW_STASH` is set, the prompt will display a symbol and the number of stash entries when there are entries in the stash.
 On Git versions older than 2.35.0 this will execute another Git command every time a new prompt is shown!
 To enable stash entries add the following line to your `.zshrc`:
 
 ```bash
 ZSH_GIT_PROMPT_SHOW_STASH=1
 ```
+
+### Disable display of numbers
+By default, the prompt will show counts for each item in the tracking status and local status sections.
+(See [Prompt Structure](#prompt-structure) for details about these sections.)
+However, you can disable the display of counts for either or both sections of the prompt using `ZSH_GIT_PROMPT_SHOW_TRACKING_COUNTS` and `ZSH_GIT_PROMPT_SHOW_LOCAL_COUNTS`.
+If you set these variables to anything other than `1`, then the symbols will be shown but not the counts.
+For example, a prompt such as `[master|✚2]` will become `[master|✚]` instead.
 
 ### Force blank
 Since the prompt is asynchronous by default, the Git status updates slightly delayed.

--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -24,6 +24,8 @@ autoload -U colors && colors
 # Settings
 : "${ZSH_GIT_PROMPT_SHOW_UPSTREAM=""}"
 : "${ZSH_GIT_PROMPT_SHOW_STASH=""}"
+: "${ZSH_GIT_PROMPT_SHOW_TRACKING_COUNTS="1"}"
+: "${ZSH_GIT_PROMPT_SHOW_LOCAL_COUNTS="1"}"
 : "${ZSH_GIT_PROMPT_ENABLE_SECONDARY=""}"
 : "${ZSH_GIT_PROMPT_NO_ASYNC=""}"
 : "${ZSH_GIT_PROMPT_FORCE_BLANK=""}"
@@ -100,6 +102,8 @@ function _zsh_git_prompt_git_status() {
         -v DETACHED="$ZSH_THEME_GIT_PROMPT_DETACHED" \
         -v BRANCH="$ZSH_THEME_GIT_PROMPT_BRANCH" \
         -v UPSTREAM_TYPE="$ZSH_GIT_PROMPT_SHOW_UPSTREAM" \
+        -v SHOW_TRACKING_COUNTS="$ZSH_GIT_PROMPT_SHOW_TRACKING_COUNTS" \
+        -v SHOW_LOCAL_COUNTS="$ZSH_GIT_PROMPT_SHOW_LOCAL_COUNTS" \
         -v UPSTREAM_SYMBOL="$ZSH_THEME_GIT_PROMPT_UPSTREAM_SYMBOL" \
         -v UPSTREAM_NO_TRACKING="$ZSH_THEME_GIT_PROMPT_UPSTREAM_NO_TRACKING" \
         -v UPSTREAM_PREFIX="$ZSH_THEME_GIT_PROMPT_UPSTREAM_PREFIX" \
@@ -204,33 +208,61 @@ function _zsh_git_prompt_git_status() {
                 }
 
                 if (behind < 0) {
-                    prompt_element(BEHIND, behind * -1);
+                    print BEHIND;
+                    if (SHOW_TRACKING_COUNTS == "1") {
+                        printf "%d", behind * -1;
+                    }
+                    print RC;
                 }
 
                 if (ahead > 0) {
-                    prompt_element(AHEAD, ahead * 1);
+                    print AHEAD;
+                    if (SHOW_TRACKING_COUNTS == "1") {
+                        printf "%d", ahead;
+                    }
+                    print RC;
                 }
 
                 prompt_element(SEPARATOR);
 
                 if (unmerged > 0) {
-                    prompt_element(UNMERGED, unmerged);
+                    print UNMERGED;
+                    if (SHOW_LOCAL_COUNTS == "1") {
+                        print unmerged;
+                    }
+                    print RC;
                 }
 
                 if (staged > 0) {
-                    prompt_element(STAGED, staged);
+                    print STAGED;
+                    if (SHOW_LOCAL_COUNTS == "1") {
+                        print staged;
+                    }
+                    print RC;
                 }
 
                 if (unstaged > 0) {
-                    prompt_element(UNSTAGED, unstaged);
+                    print UNSTAGED;
+                    if (SHOW_LOCAL_COUNTS == "1") {
+                        print unstaged;
+                    }
+                    print RC;
                 }
 
                 if (untracked > 0) {
-                    prompt_element(UNTRACKED, untracked);
+                    print UNTRACKED;
+                    if (SHOW_LOCAL_COUNTS == "1") {
+                        print untracked;
+                    }
+                    print RC;
                 }
 
-                if (stashed > 0 && SHOW_STASH != "") {
-                    prompt_element(STASHED, stashed);
+                if (stashed > 0) {
+                    print STASHED;
+                    if (SHOW_LOCAL_COUNTS == "1") {
+                        print stashed;
+                    }
+                    print RC;
                 }
 
                 if (unmerged == 0 && staged == 0 && unstaged == 0 && untracked == 0) {


### PR DESCRIPTION
By default, the prompt will show counts for both sections. But users can now easily remove the counts for either or both sections if they want.