### PR TITLE
correct version detection for apple git

### DIFF
--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -75,7 +75,7 @@ setopt PROMPT_SUBST
 
 # Use --show-stash for git versions newer than 2.35.0
 _zsh_git_prompt_git_version=$(command git version)
-if [[ "${_zsh_git_prompt_git_version:12}" == 2.<35->.<-> ]]; then
+if [[ "${_zsh_git_prompt_git_version:12}" == 2.<35->.<->* ]]; then
     _zsh_git_prompt_git_cmd() {
         GIT_OPTIONAL_LOCKS=0 command git status --show-stash --branch --porcelain=v2 2>&1 \
             || echo "fatal: git command failed"


### PR DESCRIPTION
Apple ships a current enough git version but it's not detected as supported because of the added info they append the version string. ~This trims the added data so in can be properly detected.~

[update: changed this to simply ignore any trailing chars in the version string]

macos git version looks like this:
```
% git version
git version 2.39.3 (Apple Git-146)
```